### PR TITLE
Don't power on/off if already in that state

### DIFF
--- a/custom_components/speakercraft_media/speakercraft_media.py
+++ b/custom_components/speakercraft_media/speakercraft_media.py
@@ -103,14 +103,18 @@ class SpeakerCraftZ:
 		self._queuecommand(data)
 	
 	def cmdpoweron(self):
-		_LOGGER.info("Zone " + str(self.zone) + " Power On")
-		data = bytearray([0x55, 0x04, 0xA0, self.zoneid])
-		self._queuecommand(data, True)
+
+		if self.power == "Off":
+			_LOGGER.info("Zone " + str(self.zone) + " Power On")
+			data = bytearray([0x55, 0x04, 0xA0, self.zoneid])
+			self._queuecommand(data, True)
 		
 	def cmdpoweroff(self):
-		_LOGGER.info("Zone " + str(self.zone) + " Power Off")
-		data = bytearray([0x55, 0x04, 0xA1, self.zoneid])
-		self._queuecommand(data)
+
+		if self.power == "On":
+			_LOGGER.info("Zone " + str(self.zone) + " Power Off")
+			data = bytearray([0x55, 0x04, 0xA1, self.zoneid])
+			self._queuecommand(data)
 
 	def cmdvolumeDB(self, volumedb):
 		_LOGGER.info("Zone " + str(self.zone) + " Volume " + str(volumedb))


### PR DESCRIPTION
I was getting "info" update messages when setting scenes that has the system off, even when it was already off.

Whilst it didn't cause any issues as such, it gave too verbose logs.